### PR TITLE
Return functions required for 3D MVC identification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,8 @@ install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/src/libbluray/player_settings.h
   ${CMAKE_CURRENT_SOURCE_DIR}/src/util/log_control.h
   ${CMAKE_CURRENT_SOURCE_DIR}/src/libbluray/bdnav/meta_data.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/libbluray/bdnav/mpls_data.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/libbluray/bdnav/uo_mask_table.h
   DESTINATION include/libbluray)
 
 install(FILES

--- a/cmake/libbluray.def
+++ b/cmake/libbluray.def
@@ -21,6 +21,7 @@ EXPORTS
        bd_get_playlist_info
        bd_get_sound_effect
        bd_get_title_info
+       bd_get_title_mpls
        bd_get_title_size
        bd_get_titles
        bd_get_version
@@ -66,3 +67,8 @@ EXPORTS
        bd_tell
        bd_tell_time
        bd_user_input
+       bd_clip_open
+       bd_clip_read
+       bd_clip_seek
+       bd_clip_size
+       bd_clip_close

--- a/src/libbluray/bluray.c
+++ b/src/libbluray/bluray.c
@@ -3994,6 +3994,13 @@ struct mpls_pl *bd_read_mpls(const char *mpls_file)
     return mpls_parse(mpls_file);
 }
 
+struct mpls_pl *bd_get_title_mpls(BLURAY *bd)
+{
+    if (bd != NULL && bd->title != NULL && bd->title->pl != NULL)
+        return bd->title->pl;
+    return NULL;
+}
+
 void bd_free_mpls(struct mpls_pl *pl)
 {
     mpls_free(&pl);
@@ -4017,4 +4024,69 @@ struct bdjo_data *bd_read_bdjo(const char *bdjo_file)
 void bd_free_bdjo(struct bdjo_data *obj)
 {
     bdjo_free(&obj);
+}
+
+/**
+ * Open clip file
+ *
+ * @param bd  BLURAY object
+ * @param file  name of a clip (relative to BDMV\STREAM folder)
+ * @return the bd_file_s struct if succes or nullptr otherwise
+ */
+struct bd_file_s* bd_clip_open(BLURAY *bd, const char *file)
+{
+	struct bd_file_s* fp = NULL;
+	bd_mutex_lock(&bd->mutex);
+	fp = disc_open_stream(bd->disc, file);
+	bd_mutex_unlock(&bd->mutex);
+
+	return fp;
+}
+
+/**
+ *  Seek to pos in opened file
+ *
+ * @param file  bd_file_s struct
+ * @param offset  number of bytes to offset from origin
+ * @param origin  position used as reference for the offset
+ * @return current seek position
+ */
+int64_t bd_clip_seek(struct bd_file_s* file, int64_t offset, int32_t origin)
+{
+	return file_seek(file, offset, origin);
+}
+
+/**
+ *  Read from opened file
+ *
+ * @param file  bd_file_s struct
+ * @param buf  pointer to a block of memory with a size of bytes
+ * @param size  size, in bytes, to be read.
+ * @return current position
+ */
+int64_t bd_clip_read(struct bd_file_s* file, uint8_t *buf, uint64_t size)
+{
+	file_read(file, buf, size);
+}
+
+/**
+ *  Get size of opened file
+ *
+ * @param file  bd_file_s struct
+ * @return size of file
+ */
+int64_t bd_clip_size(struct bd_file_s* file)
+{
+	return file_size(file);
+}
+
+/**
+ *  Close the file
+ *
+ * @param file  bd_file_s struct
+ * @return size of file
+ */
+void bd_clip_close(struct bd_file_s* file)
+{
+	file_close(file);
 }

--- a/src/libbluray/bluray.h
+++ b/src/libbluray/bluray.h
@@ -1079,6 +1079,7 @@ void bd_free_clpi(struct clpi_cl *cl);
 
 
 struct mpls_pl;
+struct mpls_pl *bd_get_title_mpls(BLURAY *bd);
 struct mpls_pl *bd_read_mpls(const char *mpls_file);
 void bd_free_mpls(struct mpls_pl *);
 
@@ -1094,6 +1095,15 @@ void bd_free_bdjo(struct bdjo_data *);
 
 int  bd_start_bdj(BLURAY *bd, const char* start_object); // start BD-J from the specified BD-J object (should be a 5 character string)
 void bd_stop_bdj(BLURAY *bd); // shutdown BD-J and clean up resources
+
+/**
+ * Open clip file
+ *
+ * @param bd  BLURAY object
+ * @param file  name of a clip (relative to BDMV\STREAM folder)
+ * @return the bd_file_s struct if succes or nullptr otherwise
+ */
+struct bd_file_s* bd_clip_open(BLURAY *bd, const char *file);
 
 /**
  *
@@ -1130,6 +1140,41 @@ int bd_read_file(BLURAY *, const char *path, void **data, int64_t *size);
 struct bd_dir_s *bd_open_dir(BLURAY *, const char *dir);
 struct bd_file_s *bd_open_file_dec(BLURAY *, const char *path);
 
+/**
+ *  Seek to pos in opened file
+ *
+ * @param file  bd_file_s struct
+ * @param offset  number of bytes to offset from origin
+ * @param origin  position used as reference for the offset
+ * @return current seek position
+ */
+int64_t bd_clip_seek(struct bd_file_s* file, int64_t offset, int32_t origin);
+
+/**
+ *  Read from opened file
+ *
+ * @param file  bd_file_s struct
+ * @param buf  pointer to a block of memory with a size of bytes
+ * @param size  size, in bytes, to be read.
+ * @return current position
+ */
+int64_t bd_clip_read(struct bd_file_s* file, uint8_t *buf, uint64_t size);
+
+/**
+ *  Get size of opened file
+ *
+ * @param file  bd_file_s struct
+ * @return size of file
+ */
+int64_t bd_clip_size(struct bd_file_s* file);
+
+/**
+ *  Close the file
+ *
+ * @param file  bd_file_s struct
+ * @return size of file
+ */
+void bd_clip_close(struct bd_file_s* file);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
These functions are as exposed by the libbluray 1.0.2 MVC build that is already existing in[ [kodi-dep](http://mirrors.kodi.tv/build-deps](https://ftp.heanet.ie/mirrors/xbmc/build-deps/win32/libbluray-1.0.2-mvc-x64-v141.7z) and are require for https://forum.kodi.tv/showthread.php?tid=365120&pid=3146600#pid3146600.

Until now I modified the kodi cmake files so it will download the sources from this repo, patch them and rebuild (see  https://github.com/damagedspline/xbmc/commit/05d7303c104be48533b1849d45c15dab4ca054f1).

Due to recent changes in the groovy & java requirements, i get a mismatch which breaks my existing solution and does not allow me to build kodi anymore. Hence I need this prebuild patched version to exist in kodi-dep system.

These functions are only invoked on demand, and since official code does not play 3D blurays, it cannot be affected by this flow.